### PR TITLE
fixed future::plan() for Windows machines

### DIFF
--- a/March_blavaan_Merkle/merkle_oslo_script.R
+++ b/March_blavaan_Merkle/merkle_oslo_script.R
@@ -3,7 +3,11 @@
 ##################################################
 library("blavaan")
 library("future")
-plan("multicore")
+if (.Platform$OS.type == "windows") {
+  plan("multisession")
+} else {
+  plan("multicore")
+}
 library("bayesplot")
 
 


### PR DESCRIPTION
This PR allows users to run the script's {future} functionalities independent of the used architecture: `future::plan("multisession")` for Windows, and `future::plan("multicore")` for Unix-like systems (Linux and macOS). 